### PR TITLE
施設と動物の中間テーブルを作成

### DIFF
--- a/app/models/management.rb
+++ b/app/models/management.rb
@@ -1,0 +1,6 @@
+class Management < ApplicationRecord
+  belongs_to :facility
+  belongs_to :animal
+
+  validates :facility_id, uniqueness: { scope: :animal_id }
+end

--- a/db/migrate/20220902023442_create_managements.rb
+++ b/db/migrate/20220902023442_create_managements.rb
@@ -1,0 +1,12 @@
+class CreateManagements < ActiveRecord::Migration[6.1]
+  def change
+    create_table :managements do |t|
+      t.references :facility, null: false, foreign_key: true
+      t.references :animal, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :managements, [:facility_id, :animal_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_02_004244) do
+ActiveRecord::Schema.define(version: 2022_09_02_023442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,16 @@ ActiveRecord::Schema.define(version: 2022_09_02_004244) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "managements", force: :cascade do |t|
+    t.bigint "facility_id", null: false
+    t.bigint "animal_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["animal_id"], name: "index_managements_on_animal_id"
+    t.index ["facility_id", "animal_id"], name: "index_managements_on_facility_id_and_animal_id", unique: true
+    t.index ["facility_id"], name: "index_managements_on_facility_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "name", null: false
@@ -49,4 +59,6 @@ ActiveRecord::Schema.define(version: 2022_09_02_004244) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "managements", "animals"
+  add_foreign_key "managements", "facilities"
 end


### PR DESCRIPTION
## 概要

##### 施設と動物の中間テーブル`managements`テーブルを作成

- 以下のコマンドでモデルとマイグレーションファイルを作成
```
bundle exec rails g model management facility:references animal:references
```

- マイグレーションファイルに以下を追加して`db:migrate`を実行
```
add_index :managements, [:facility_id, :animal_id], unique: true
```

- モデルにも一意のバリデーションを設定
```
validates :facility_id, uniqueness: { scope: :animal_id }
```

