### PR TITLE
非ログイン時のエラーを解消

### DIFF
--- a/app/views/facilities/_before_login_bookmark.html.erb
+++ b/app/views/facilities/_before_login_bookmark.html.erb
@@ -1,0 +1,6 @@
+<%= link_to login_path do %>
+  <button class="btn gap-2">
+    お気に入り
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" /></svg>
+  </button>
+<% end %>

--- a/app/views/facilities/_facility.html.erb
+++ b/app/views/facilities/_facility.html.erb
@@ -20,6 +20,10 @@
         <button class="btn btn-primary">詳細を見る</button>
       <% end %>
     </div>
-    <%= render 'bookmark_button', facility: facility %>
+    <% if logged_in? %>
+      <%= render 'bookmark_button', facility: facility %>
+    <% else %>
+      <%= render 'before_login_bookmark' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -4,7 +4,10 @@
       <h1 id="facility-title" class="mb-8 text-2xl font-light text-center text-black">
         <%= @facility.name %>
       </h1>
-      <%= render 'bookmark_button', { facility: @facility } %>
+      <% if logged_in? %>
+        <%= render 'bookmark_button', { facility: @facility } %>
+      <% else %>
+        <%= render 'before_login_bookmark' %>
       <h2 class="mb-8 text-2xl font-light text-center text-black">
         <% @facility.categories.each do |category| %>
           <%= category.name %>


### PR DESCRIPTION
## 概要

- 非ログイン時に検索をするとエラーが発生したので解消

### 原因

施設のビューに設置していたお気に入りボタンにログインユーザー用のメソッドがあったので非ログイン時に`undefind_method`となっていた

facilities/_bookmark_button.html.erb
```
<% if current_user.bookmark?(facility) %>
  <%= render 'unbookmark', { facility: facility } %>
<% else %>
  <%= render 'bookmark', { facility: facility } %>
<% end %>
```


## 解決方法
- 以下の２つの選択肢が思いつきました。
  - 非ログイン時はお気に入りボタンを表示しない
  - 非ログイン時にお気に入りボタンを押すとログイン画面に遷移する


- お気に入りをしようとしてくれたユーザーに是非ともユーザー登録をしてお気に入り機能を使っていただきたいので後者の「お気に入りボタンを押すとログイン画面に遷移する」という選択肢を取りました



