### PR TITLE
お気に入りした施設をGoogleマップにまとめて表示する

### DIFF
--- a/app/assets/stylesheets/facility.scss
+++ b/app/assets/stylesheets/facility.scss
@@ -2,6 +2,10 @@
   margin: 20px;
 }
 
+.facility-link {
+  color: rgb(46, 102, 255);
+}
+
 #post-button:hover {
   background-color: rgb(11, 83, 217);
   border-color: rgb(11, 83, 217);

--- a/app/assets/stylesheets/facility.scss
+++ b/app/assets/stylesheets/facility.scss
@@ -26,3 +26,8 @@
   border-color: rgb(255, 96, 183);
 }
 
+#map {
+  height: 500px;
+  width: 100%;
+}
+

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -1,5 +1,8 @@
 class FacilitiesController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
+  before_action :set_center_of_show_map, only: %i[show]
+  before_action :set_center_of_bookmarks_map, only: %i[bookmarks]
+
   def index
     @search_form = SearchForm.new(search_params)
     @facilities = @search_form.search.order(id: :desc)
@@ -7,16 +10,30 @@ class FacilitiesController < ApplicationController
 
   def show
     @facility = Facility.find(params[:id])
-    gon.facility = @facility
+    gon.facility = [@facility]
   end
 
   def bookmarks
     @bookmark_facilities = current_user.facilities.includes(%i[facility_categories categories managements animals]).order(created_at: :desc)
+    gon.facility = @bookmark_facilities
   end
 
   private
 
   def search_params
     params[:q]&.permit(:name, :description, :address, :prefecture_id, :category_id, :animal_id)
+  end
+
+  def set_center_of_show_map
+    @facility = Facility.find(params[:id])
+    gon.center_lat = @facility.latitude
+    gon.center_lng = @facility.longitude
+    gon.zoom_level = 15
+  end
+
+  def set_center_of_bookmarks_map
+    gon.center_lat = 35.509889
+    gon.center_lng = 139.409462
+    gon.zoom_level = 9.6
   end
 end

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -1,7 +1,8 @@
 let facilityLatLng;
 const marker = [];
+const infoWindow = [];
 
-  window.initMap = () => {
+function initMap() {
   const map_center = { lat: gon.center_lat, lng: gon.center_lng };
   const zoom_level = gon.zoom_level;
   const map = new google.maps.Map(document.getElementById("map"), {
@@ -24,5 +25,23 @@ const marker = [];
       position: facilityLatLng,
       map: map,
     })
+
+    const id = facility[i]['id']
+    const c = facility[i]['categories']
+    const infoContent = 
+    `<div class="facility-link map">` +
+    `<a href="/facilities/${id}" data-turbolinks="false"><u>${facility[i]['name']}</u></a>` +
+    `</div>` +
+    `<p>${facility[i]['address']}</p>`;
+
+    infoWindow[i] = new google.maps.InfoWindow({
+      content: infoContent
+    })
+
+    marker[i].addListener('click', function () {
+      infoWindow[i].open(map, marker[i])
+    })
   }
 }
+
+window.initMap = initMap;

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -1,0 +1,28 @@
+let facilityLatLng;
+const marker = [];
+
+  window.initMap = () => {
+  const map_center = { lat: gon.center_lat, lng: gon.center_lng };
+  const zoom_level = gon.zoom_level;
+  const map = new google.maps.Map(document.getElementById("map"), {
+    center: map_center,
+    zoom: zoom_level,
+  })
+
+  // 施設の情報を配列で取得
+  const facility = gon.facility;
+
+  for (let i = 0; i < facility.length; i++) {
+
+    // LatLngで位置座標のインスタンスを生成していく
+    facilityLatLng = new google.maps.LatLng({
+      lat: facility[i]['latitude'],
+      lng: facility[i]['longitude'],
+    })
+
+    marker[i] = new google.maps.Marker({
+      position: facilityLatLng,
+      map: map,
+    })
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 import "stylesheets/application.css"
 import "custom/preview"
+import "google_maps"
 require('jquery')
 
 Rails.start()

--- a/app/views/facilities/bookmarks.html.erb
+++ b/app/views/facilities/bookmarks.html.erb
@@ -3,6 +3,7 @@
     <%= t('.title') %>
   </p>
   <% if @bookmark_facilities.present? %>
+    <div id='map' class='mb-6'></div>
     <%= render @bookmark_facilities %>
   <% else %>
     <p><%= t('.no_result') %></p>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -78,27 +78,3 @@
     </div>
   </div>
 </div>
-
-<style>
-  #map {
-    height: 500px;
-    width: 100%;
-  }
-</style>
-
-<script>
-  function initMap() {
-    const myFacility = { lat: gon.facility.latitude, lng: gon.facility.longitude }
-    const map = new google.maps.Map(document.getElementById("map"), {
-      center: myFacility,
-      zoom: 15,
-    })
-    const marker = new google.maps.Marker({
-      position: myFacility,
-      map: map,
-    })
-  }
-  window.initMap = initMap;
-</script>
-
-<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,4 +22,5 @@
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>
+  <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
 </html>


### PR DESCRIPTION
## 概要

参考記事
１、
https://github.com/shota-hope/True_Neapolitan_Pizza_Club
２、
https://qiita.com/japwork/items/1d01663b462264ab92a9
３、
https://qiita.com/pomusuke36/items/3fc6208628cbfe501686
４、
https://developers.google.com/maps/documentation/javascript/infowindows?hl=ja

- お気に入りに登録した施設の情報を`JavaScriot`で使えるように`facilities`コントローラで変数に格納

- 施設詳細画面のマップと同じJSファイルで統一できそうなので`facilities`コントローラの`show`アクションと`bookmark`アクションで同じ名前の変数に統一 6e9a61fbaeab5538690f96270859d31a1c2b0b52
```
  def show
    @facility = Facility.find(params[:id])
    gon.facility = [@facility]
  end

  def bookmarks
    @bookmark_facilities = current_user.facilities.includes(%i[facility_categories categories managements animals]).order(created_at: :desc)
    gon.facility = @bookmark_facilities
  end

  private

  def set_center_of_show_map
    @facility = Facility.find(params[:id])
    gon.center_lat = @facility.latitude
    gon.center_lng = @facility.longitude
    gon.zoom_level = 15
  end

  def set_center_of_bookmarks_map
    gon.center_lat = 35.509889
    gon.center_lng = 139.409462
    gon.zoom_level = 9.6
  end
```

- Googleマップ用のJSファイルを作成してマップを表示する処理を記述する

#### 施設詳細、お気に入り一覧のマップの中心の位置はそれぞれコントローラの変数にあらかじめ設定しているので、JSファイルでは`center`、`zoom`に共通の変数を設定するだけでマップが表示される

#### マップに表示するピンの設定を`for`文で実装

- `new google.maps.LatLng`で位置座標のインスタンスを作成
- 作成したインスタンスの場所にマーカーを立てるようにする
- つまり詳細画面のマップ、お気に入り一覧画面のマップでは以下のようになる
  - 施設詳細　 その施設の位置にピンが立ち、中心位置は施設の場所になる

  - お気に入り一覧   お気に入りにしている施設すべての位置にピンが立ち、中心はコントローラで設定した固定の位置になる

#### 吹き出しを作成

- `new google.maps.InfoWindow`でピンをクリックした時にでる吹き出しを設定

  - 現在、詳細画面へのリンクになっている「施設名」と、「住所」が表示される
  - 後日別のブランチでカテゴリーを一覧表示できるように実装する


## コメント

- お気に入り一覧画面でマーカーの吹き出しのリンクで詳細画面に遷移し、元いたお気に入り一覧画面にブラウザバックするとマップが詳細画面のマップのままになっているバグが発生

### ↓

吹き出しのリンクに対して`turbolinks`を無効にすることで解決

