### PR TITLE
ログイン状態を長く保持できるように設定

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember])
     if @user
       redirect_back_or_to root_path, success: t('.success')
     else

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -26,6 +26,6 @@ class SearchForm
   private
 
   def search_words
-    name.present? ? name.split(nil) : []
+    name.present? ? name.split(/[[:blank:]]+/) : []
   end
 end

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -12,6 +12,17 @@
           <div class="mb-4 flex-1">
             <%= f.password_field :password, value: params[:password], placeholder: 'パスワード', class: 'input input-bordered input-info w-full max-w-xs' %>
           </div>
+          <div class="flex items-center mt-8">
+            <div>
+              <%= check_box_tag :remember, params[:remember], true, class: 'mx-1' %>
+            </div>
+            <div>
+              <%= label_tag t('.remember') %>
+            </div>
+          </div>
+          <div>
+            <p>時間が経ってもログイン状態を保てるようになります</p>
+          </div>
           <div class="actions flex items-center justify-between mt-4">
             <%= f.submit (t 'defaults.login'), type: 'submit', class: 'cursor-pointer py-2 px-4  bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500 focus:ring-offset-indigo-200 text-white w-full transition ease-in duration-200 text-center text-base font-semibold shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2  rounded-lg' %>
           </div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = [:reset_password]
+Rails.application.config.sorcery.submodules = [:reset_password, :remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -318,8 +318,8 @@ Rails.application.config.sorcery.configure do |config|
 
     # How long in seconds the session length will be
     # Default: `60 * 60 * 24 * 7`
-    #
-    # user.remember_me_for =
+    # 自動ログインの期間を半年に設定
+    user.remember_me_for = 15552000
 
     # When true, sorcery will persist a single remember me token for all
     # logins/logouts (to support remembering on multiple browsers simultaneously).

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -24,6 +24,7 @@ ja:
       title: 'ログイン'
       to_register_page: '登録ページへ'
       password_forget: 'パスワードをお忘れの方はこちら'
+      remember: 'ログイン状態を保持'
     create:
       success: 'ログインしました'
       error: 'ログインに失敗しました。 メールアドレス、パスワードが間違っていないかご確認ください'

--- a/db/migrate/20221003032844_sorcery_remember_me.rb
+++ b/db/migrate/20221003032844_sorcery_remember_me.rb
@@ -1,0 +1,8 @@
+class SorceryRememberMe < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :remember_me_token, :string, default: nil
+    add_column :users, :remember_me_token_expires_at, :datetime, default: nil
+
+    add_index :users, :remember_me_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_01_074513) do
+ActiveRecord::Schema.define(version: 2022_10_03_032844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,7 +153,10 @@ ActiveRecord::Schema.define(version: 2022_10_01_074513) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
## 概要

#### 公式を参考に`sorcery`の`remember_me`モジュールを使ってログイン状態を長く保持できるように設定
[sorcery/remember_me](https://github.com/Sorcery/sorcery/wiki/Remember-Me)

- 以下のコマンドを実行
```
bundle exec rails g sorcery:install remember_me --only-submodules
```

- マイグレーションファイルが作成されるので`db:migrate`を実行

- `user_sessins_controller.rb`を編集

- `config/initializers/sorcery.rb`でセッションの期限を設定

- ログイン画面に確認のチェックボックスを設置


[![Image from Gyazo](https://i.gyazo.com/c71f6f77fc5f44893dcfcd32c91c5d07.png)](https://gyazo.com/c71f6f77fc5f44893dcfcd32c91c5d07)


## 確認方法

１、ログイン画面でチェックを入れてログインする

２、コンソールで追加したカラムが`nil`である事を確認してください

３、今度はチェックを入れてログインする

４、カラムに値が保存されている事を確認してください
```
remember_me_token: "SYzPrp〇〇〇〇〇〇〇〇",
remember_me_token_expires_at: Sun, 02 Apr 2023 〇〇〇〇.160436000 UTC +00:00>
```

