### PR TITLE
投稿削除機能を実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,9 +20,9 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    @post = Post.find(params[:id])
+    @post = current_user.posts.find(params[:id])
     @post.destroy!
-    redirect_to facility_path(@post.facility)
+    flash.now[:success] = t('.success')
   end
 
   private

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,9 @@
 class ProfilesController < ApplicationController
   before_action :set_user, only: %i[edit update]
 
-  def show; end
+  def show
+    @posts = current_user.posts
+  end
 
   def edit; end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,3 +15,7 @@ require('jquery')
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
+
+$(function(){
+  setTimeout("$('#flash-message').fadeOut('slow')", 2000);
+});

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <div class="top-wrapper">
   <div class="top-title-object">
-    <h1 class="top-title">FLUFF MAPS</h1>
+    <h1 class="top-title flex">FLUFF MAPS<%= image_tag 'top_animal_icon.png', size: '80', class: 'mx-3' %></h1>
     <h2 class="top-message">動物とふれあえる施設を検索できるサービスです</h2>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,9 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <%= render 'shared/flash_message' %>
+    <div id="flash-message">
+      <%= render 'shared/flash_message' %>
+    </div>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/posts/destroy.js.erb
+++ b/app/views/posts/destroy.js.erb
@@ -1,0 +1,2 @@
+$("div#post-<%= @post.id %>").remove()
+$("#flash-message").html("<%= j(render 'shared/flash_message') %>")

--- a/app/views/profiles/_posts.html.erb
+++ b/app/views/profiles/_posts.html.erb
@@ -1,0 +1,15 @@
+<div class="post-content">
+  <% posts.each do |post| %>
+    <div class="post-object"  id="post-<%= post.id %>">
+      <div class="post-image">
+        <%= image_tag post.image.url %>
+      </div>
+      <div class="flex justify-between float-right">
+        <%= post.title %>
+        <%= link_to post_path(post), class: 'js-delete-post', method: :delete, data: { confirm: t('defaults.message.delete_confirm')}, remote: true do %>
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,9 @@
 <div class="container pt-3 center mx-auto justify-center text-center">
   <div class="row">
-    <%= link_to t('defaults.edit'), edit_profile_path, class: 'btn btn-outline float-right' %>
-    <h3 class="text-5xl"><%= t('.title') %></h3>
+    <div class="flex max-auto justify-center">
+      <h3 class="text-5xl mr-2"><%= t('.title') %></h3>
+      <%= link_to t('defaults.edit'), edit_profile_path, class: 'btn btn-accent text-white' %>
+    </div>
     <div class="avatar">
       <div class="w-28 mask mask-squircle m-4">
         <%= image_tag current_user.avatar.url %>
@@ -34,6 +36,9 @@
       <div>
         <%= current_user.category.name if current_user.category.present? %>
       </div>
+    </div>
+    <div>
+      <%= render 'posts', posts: @posts %>
     </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,6 +11,7 @@ ja:
       require_login: 'ログインしてください'
       updated: 'プロフィールを編集しました'
       not_updated: 'プロフィールを編集できませんでした'
+      delete_confirm: '投稿を削除してもよろしいですか？'
   users:
     new:
       title: 'ユーザー登録'
@@ -53,7 +54,8 @@ ja:
     create:
       success: '投稿しました'
       error: '投稿できませんでした'
-    destroy: '投稿を削除しました'
+    destroy:
+      success: '投稿を削除しました'
   reports:
     new:
       title: '報告フォーム'


### PR DESCRIPTION
## 概要

#### プルフィール詳細画面に自身の投稿を一覧で表示し、削除ボタンを設置して削除できるようにする

- 削除ボタンのリンクに`id` を設定し`remote: true`で非同期を有効にする
```
<%= link_to post_path(post), class: 'js-delete-post', method: :delete, remote: true do %>
```

- `app/views/posts`ディレクトリに`destroy.js.erb`を作成して画面から投稿を消す処理を記述
```
$("div#post-<%= @post.id %>").remove()

フラッシュメッセージも設定
$("#flash-message").html("<%= j(render 'shared/flash_message') %>")
```


- フラッシュメッセージが自動で消えるように設定
```
$(function(){
  setTimeout("$('#flash-message').fadeOut('slow')", 2000);  ※2秒に設定
});
```


## コメント

- 非同期で実装した投稿削除機能のフラッシュメッセージが自動で消えないので別途ブランチを作成して対応

- 投稿した写真をモーダルでプレビューできる機能を作りたい
  - モーダル内に施設名や住所などを表示する
