### PR TITLE
新規登録時のエラーを解消

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -7,9 +7,17 @@ class ApplicationRecord < ActiveRecord::Base
   def suggest_to_login_user(user)
     animal = user.animal
     category = user.category
-    facilities = Facility.offset(rand(Facility.count)).limit(100)
-    suggest_animal_facilities = facilities.favo_animal(animal).to_a
-    suggest_category_facilities = facilities.favo_category(category).to_a
-    suggest_animal_facilities.concat(suggest_category_facilities).uniq.sample(3)
+    hoge(animal, category)
+  end
+
+  def hoge(animal, category)
+    facilities = Facility.limit(100).offset(rand(5))
+    if !animal && !category
+      facilities.where(suggest: 1).includes(%i[facility_categories categories managements animals]).sample(3)
+    else
+      suggest_animal_facilities = animal ? facilities.favo_animal(animal).to_a : []
+      suggest_category_facilities = category ? facilities.favo_category(category).to_a : []
+      suggest_animal_facilities.concat(suggest_category_facilities).uniq.sample(3)
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   config.after_initialize do
     Bullet.enable        = true
-    Bullet.alert         = true
+    Bullet.alert         = false
     Bullet.bullet_logger = true
     Bullet.console       = true
     Bullet.rails_logger  = true


### PR DESCRIPTION
## 概要

- 新規登録時にお気に入りの動物とカテゴリが`nil`の状態なのでエラーが起きていました

- トップページに表示するオススメの施設を取得するメソッドを修正してエラーが起きないようにしました