### PR TITLE
本番環境でメールを送る設定

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'info@fluff-maps.com'
   layout 'mailer'
 end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -2,7 +2,7 @@ class ReportMailer < ApplicationMailer
   def send_mail
     @report = params[:report]
     mail(
-      to: 'report@example.com',
+      to: ENV['ADMIN_EMAIL_ADDRESS'],
       subject: '報告通知'
     )
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,17 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "fluff_navi_production"
 
   config.action_mailer.perform_caching = false
-
+  config.action_mailer.default_url_options = { host: 'https://www.fluff-maps.com' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address => 'smtp.sendgrid.net',
+    :port => 587,
+    :domain => 'fluff-maps.com',
+    :authentication => :plain,
+    :user_name => ENV['SENDGRID_USERNAME'],
+    :password => ENV['SENDGRID_PASSWORD'],
+  }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
## 概要

- `SendGrid`のユーザー登録を行う
- Herokuに`SendGrid`を以下のコマンドで追加する
```
%  heroku addons:create sendgrid:starter
```

- APIキーをHerokuに設定する

- `config/environments/production.rb`に設定を記載


#### 参考記事

[SendGrid公式](https://sendgrid.kke.co.jp/)
[ActionMailer公式](https://railsguides.jp/action_mailer_basics.html)
https://asalworld.com/rails-heroku-sendgrid/
https://qiita.com/miriwo/items/46a58bd92f74f0dc74d8


